### PR TITLE
Update UndoRedoState5 

### DIFF
--- a/docs/diagrams/UndoRedoState5.puml
+++ b/docs/diagrams/UndoRedoState5.puml
@@ -7,9 +7,9 @@ skinparam ClassBackgroundColor #FFFFAA
 title After command "clear"
 
 package States <<rectangle>> {
-    class State1 as "<u>ab0:AddressBook</u>"
-    class State2 as "<u>ab1:AddressBook</u>"
-    class State3 as "<u>ab3:AddressBook</u>"
+    class State1 as "<u>rd0:RestaurantDirectory</u>"
+    class State2 as "<u>rd1:RestaurantDirectory</u>"
+    class State3 as "<u>rd3:RestaurantDirectory</u>"
 }
 
 State1 -[hidden]right-> State2
@@ -18,5 +18,5 @@ State2 -[hidden]right-> State3
 class Pointer as "Current State" #FFFFFF
 
 Pointer -up-> State3
-note right on link: State ab2 deleted.
+note right on link: State rd2 deleted.
 @end


### PR DESCRIPTION
Fixes #157 

Revised UndoRedoState5.puml to accurately depict the system state after executing the `clear` command in the versioned RestaurantDirectory:
- Updated state labels from ab0–ab3 to match current naming conventions
- Clarified that the state pointer moves to the latest RestaurantDirectory snapshot after clear

This improves consistency across the Undo/Redo state sequence diagrams and ensures the Developer Guide reflects the latest undo-redo logic.