### PR TITLE
Fix command letter casing issue

### DIFF
--- a/src/main/java/foodtrail/logic/parser/RestaurantDirectoryParser.java
+++ b/src/main/java/foodtrail/logic/parser/RestaurantDirectoryParser.java
@@ -49,7 +49,7 @@ public class RestaurantDirectoryParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        final String commandWord = matcher.group("commandWord");
+        final String commandWord = matcher.group("commandWord").toLowerCase();
         final String arguments = matcher.group("arguments");
 
         // Note to developers: Change the log level in config.json to enable lower level


### PR DESCRIPTION
Fixes #173 #174 #181 #182 #183 #204 #205 #206 #211 #212 

Fixed the problem where capitalized commands are not detected as correct commands.