### PR TITLE
Add length restriction for name and tag

### DIFF
--- a/src/main/java/foodtrail/model/restaurant/Address.java
+++ b/src/main/java/foodtrail/model/restaurant/Address.java
@@ -17,7 +17,6 @@ public class Address {
             Address should not be empty, not exceed 100 characters,
             and must end with ', Singapore' followed by a 6-digit postal code.
             Preferred format: [Street Address], [Building Name], Singapore [Postal Code].
-            Spaces within the postal code will be ignored for validation.
             """;
 
     public final String value;
@@ -49,7 +48,7 @@ public class Address {
 
         // 3. Use regex to split address into main part and postal code
         // The postal code must be preceded by a comma, "Singapore", and mandatory whitespace.
-        Pattern addressPattern = Pattern.compile("^(.*),\\s+Singapore\\s+((\\d\\s*){6})$", Pattern.CASE_INSENSITIVE);
+        Pattern addressPattern = Pattern.compile("^(.*),\\s+Singapore\\s+((\\d\\s*){6})$");
         Matcher addressMatcher = addressPattern.matcher(test);
 
         if (!addressMatcher.matches()) {

--- a/src/main/java/foodtrail/model/restaurant/Name.java
+++ b/src/main/java/foodtrail/model/restaurant/Name.java
@@ -9,7 +9,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class Name {
 
-    public static final String MESSAGE_CONSTRAINTS = "Names should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Names should not be empty, and can be at most 60 characters";
     public static final String VALIDATION_REGEX = ".*\\S.*";
     public final String fullName;
 
@@ -28,6 +28,9 @@ public class Name {
      * Returns true if a given string is a valid name.
      */
     public static boolean isValidName(String test) {
+        if (test.length() > 60) {
+            return false;
+        }
         return test.matches(VALIDATION_REGEX);
     }
 

--- a/src/main/java/foodtrail/model/restaurant/Phone.java
+++ b/src/main/java/foodtrail/model/restaurant/Phone.java
@@ -11,7 +11,7 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be exactly 8 digits long, "
+            "Phone numbers should only contain numbers, be exactly 8 digits, "
                     + "and start with 6, 8 or 9.";
     public static final String VALIDATION_REGEX = "^[689]\\d{7}$";
     public final String value;

--- a/src/main/java/foodtrail/model/restaurant/Tag.java
+++ b/src/main/java/foodtrail/model/restaurant/Tag.java
@@ -9,7 +9,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags should be alphanumeric.";
+    public static final String MESSAGE_CONSTRAINTS = "Tags should be alphanumeric, and be at most 30 characters.";
     public static final String VALIDATION_REGEX = "[\\p{Alnum} ]+";
 
     public final String tagName;
@@ -29,6 +29,9 @@ public class Tag {
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidTagName(String test) {
+        if (test.length() > 30) {
+            return false;
+        }
         return test.matches(VALIDATION_REGEX);
     }
 

--- a/src/test/java/foodtrail/model/restaurant/AddressTest.java
+++ b/src/test/java/foodtrail/model/restaurant/AddressTest.java
@@ -41,12 +41,12 @@ public class AddressTest {
         assertFalse(Address.isValidAddress("123 Main Street, Singapore123456")); // missing space after Singapore
         assertFalse(Address.isValidAddress("123 Main St!, Singapore 123456")); // invalid character '!'
         assertFalse(Address.isValidAddress("Baker & Cook, Singapore 123456")); // invalid character '&'
+        assertFalse(Address.isValidAddress("1 Raffles Place, #39-01, singapore 048616")); // lowercase singapore
 
         // valid addresses
         assertTrue(Address.isValidAddress("50 Sixth Avenue, Singapore 276496"));
         assertTrue(Address.isValidAddress(" 2 Orchard Turn, #4-01 ION Orchard, Singapore 238801")); // long address
         assertTrue(Address.isValidAddress("456 Oak Avenue, Singapore 1 2 3 4 5 6")); // postal code with spaces
-        assertTrue(Address.isValidAddress("1 Raffles Place, #39-01, singapore 048616")); // lowercase singapore
     }
 
     @Test

--- a/src/test/java/foodtrail/model/restaurant/NameTest.java
+++ b/src/test/java/foodtrail/model/restaurant/NameTest.java
@@ -29,11 +29,13 @@ public class NameTest {
         // invalid name
         assertFalse(Name.isValidName("")); // empty string
         assertFalse(Name.isValidName(" ")); // spaces only
+        assertFalse(Name.isValidName("abc def ghi jkl mno pqrs tuv wxyz ABC DEF GHI JKL MNO PQRS Ta")); // 61 characters
 
         // valid name
         assertTrue(Name.isValidName("KFC")); // only alphabets
         assertTrue(Name.isValidName("McDonald's")); // with apostrophe
         assertTrue(Name.isValidName("KOI Thé")); // accent characters
+        assertTrue(Name.isValidName("abc def ghi jkl mno pqrs tuv wxyz ABC DEF GHI JKL MNO PQRS T")); // 60 characters
     }
 
     @Test

--- a/src/test/java/foodtrail/model/restaurant/PhoneTest.java
+++ b/src/test/java/foodtrail/model/restaurant/PhoneTest.java
@@ -30,6 +30,7 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("")); // empty string
         assertFalse(Phone.isValidPhone(" ")); // spaces only
         assertFalse(Phone.isValidPhone("91")); // less than 8 numbers
+        assertFalse(Phone.isValidPhone("9191919191")); // more than 8 numbers
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits

--- a/src/test/java/foodtrail/model/restaurant/TagTest.java
+++ b/src/test/java/foodtrail/model/restaurant/TagTest.java
@@ -23,6 +23,14 @@ public class TagTest {
     public void isValidTagName() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+        // invalid tag name
+        assertFalse(Tag.isValidTagName("")); // empty string
+        assertFalse(Tag.isValidTagName("abc def ghi jkl mno pqrs tuv we")); // 31 characters
+
+        // valid tag names
+        assertTrue(Tag.isValidTagName("halal"));
+        assertTrue(Tag.isValidTagName("abc def ghi jkl mno pqrs tuv w")); // 30 characters (spaces)
+        assertTrue(Tag.isValidTagName("abcedefeghiejklemnoepqrsetuvew")); // 30 characters (no spaces)
     }
 
     @Test


### PR DESCRIPTION
Fixes #248
- Name is at most 60 characters and tag is at most 30 characters.
- Added test cases for above changes.
- Modified invalid phone number message.
- Change "Singapore" in Address to be case-sensitive. 