### PR TITLE
Fix invalid ratings crashing during load

### DIFF
--- a/src/main/java/foodtrail/storage/JsonAdaptedRestaurant.java
+++ b/src/main/java/foodtrail/storage/JsonAdaptedRestaurant.java
@@ -105,8 +105,16 @@ class JsonAdaptedRestaurant {
 
         final Set<Tag> modelTags = new HashSet<>(restaurantTags);
 
-        final Optional<Rating> modelRating = (rating == null) ? java.util.Optional.empty()
-                : java.util.Optional.of(new Rating(rating));
+        final Optional<Rating> modelRating;
+        if (rating == null) {
+            modelRating = Optional.empty();
+        } else {
+            try {
+                modelRating = Optional.of(new Rating(rating));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalValueException(Rating.MESSAGE_CONSTRAINTS, e);
+            }
+        }
 
         final IsMarked modelIsMarked = new IsMarked(isMarked != null && isMarked);
 

--- a/src/test/java/foodtrail/storage/JsonAdaptedRestaurantTest.java
+++ b/src/test/java/foodtrail/storage/JsonAdaptedRestaurantTest.java
@@ -102,17 +102,17 @@ public class JsonAdaptedRestaurantTest {
     }
 
     @Test
-    public void toModelType_invalidRatingNegative_throwsIllegalArgumentException() {
+    public void toModelType_invalidRatingNegative_throwsIllegalValueException() {
         JsonAdaptedRestaurant restaurant =
                 new JsonAdaptedRestaurant(VALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_TAGS, -1, VALID_IS_MARKED);
-        assertThrows(IllegalArgumentException.class, Rating.MESSAGE_CONSTRAINTS, restaurant::toModelType);
+        assertThrows(IllegalValueException.class, Rating.MESSAGE_CONSTRAINTS, restaurant::toModelType);
     }
 
     @Test
-    public void toModelType_invalidRatingTooLarge_throwsIllegalArgumentException() {
+    public void toModelType_invalidRatingTooLarge_throwsIllegalValueException() {
         JsonAdaptedRestaurant restaurant =
                 new JsonAdaptedRestaurant(VALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_TAGS, 10, VALID_IS_MARKED);
-        assertThrows(IllegalArgumentException.class, Rating.MESSAGE_CONSTRAINTS, restaurant::toModelType);
+        assertThrows(IllegalValueException.class, Rating.MESSAGE_CONSTRAINTS, restaurant::toModelType);
     }
 
     @Test


### PR DESCRIPTION
Fixes #336 

- wrap Rating construction in JsonAdaptedRestaurant so out-of-range values raise IllegalValueException instead of crashing
- update JsonAdaptedRestaurantTest expectations for invalid ratings