### PR TITLE
Fix list to sort them by lexicographical order

### DIFF
--- a/src/main/java/foodtrail/model/ModelManager.java
+++ b/src/main/java/foodtrail/model/ModelManager.java
@@ -118,7 +118,9 @@ public class ModelManager implements Model {
     @Override
     public void sortRestaurantListByName() {
         // Sorts the backing list; FilteredList reflects the new order automatically.
-        restaurantDirectory.sortRestaurant(Comparator.comparing(r -> r.getName().fullName.toLowerCase()));
+        restaurantDirectory.sortRestaurant(
+                Comparator.comparing((Restaurant r) -> r.getName().fullName, String.CASE_INSENSITIVE_ORDER)
+                        .thenComparing(r -> r.getName().fullName));
         // Keep current filter predicate as-is so the user’s filtered view remains, just
         // sorted.
         filteredRestaurants.setPredicate(filteredRestaurants.getPredicate());


### PR DESCRIPTION
Fixes #317 

Sort restaurants case-insensitively

- update ModelManager.sortRestaurantListByName to compare names using String.CASE_INSENSITIVE_ORDER with a case-sensitive tie-breaker
- ensures the list command consistently orders entries regardless of letter casing
